### PR TITLE
Add poetcore theme with fonts, overflow fixes, and mauve palette

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -8,6 +8,24 @@
   <meta name="theme-color" content="#000000" />
   <meta name="description" content="Web site created using create-react-app" />
   <link rel="apple-touch-icon" href="%PUBLIC_URL%/logo192.png" />
+  <script>
+    (function() {
+      var THEME_KEY = 'portfolio-theme';
+      var BG_MAP = { 'dark-minimal': '#000000', 'poetcore': '#E3DADB' };
+      var saved = '';
+      try { saved = localStorage.getItem(THEME_KEY) || ''; } catch(e) {}
+      if (!BG_MAP[saved]) saved = 'dark-minimal';
+      document.documentElement.setAttribute('data-theme', saved);
+      document.documentElement.style.backgroundColor = BG_MAP[saved];
+      if (saved === 'poetcore') {
+        var link = document.createElement('link');
+        link.rel = 'stylesheet';
+        link.href = 'https://fonts.googleapis.com/css2?family=EB+Garamond:ital,wght@0,400;0,500;0,600;1,400;1,500&family=Pinyon+Script&family=Bodoni+Moda:wght@400;700&family=Cinzel:wght@400;500;600;700&display=swap';
+        link.setAttribute('data-theme-fonts', 'true');
+        document.head.appendChild(link);
+      }
+    })();
+  </script>
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link href="https://fonts.googleapis.com/css2?family=Poppins:wght@100;300;400;700&display=swap" rel="stylesheet">

--- a/src/App.js
+++ b/src/App.js
@@ -3,6 +3,7 @@ import { Routes, Route } from 'react-router-dom';
 
 import Header from './components/Header';
 import SkillsList from './components/SkillsList';
+import ThemeModal from './components/ThemeModal';
 // SpinnerLoader removed — MainLoader handles the initial wait
 import MainLoader from "./components/MainLoader";
 
@@ -24,6 +25,7 @@ function App() {
 
   return (
     <div className="app-content-enter">
+      <ThemeModal />
       <Header />
       <Routes className="routes">
         <Route path="/" exact element={<Suspense fallback={null}><Homepage /></Suspense>} />

--- a/src/components/Designation/index.js
+++ b/src/components/Designation/index.js
@@ -4,7 +4,7 @@ const Designation = () => {
   return (
     <div className="designation">
       <h1>Hi, I'm <span className="designation_name">Priyanshi</span></h1>
-      <h2>an <span className="designation_role">AI FRONTEND ENGINEER</span></h2>
+      <h2><span className="designation_an">an </span><span className="designation_role">AI FRONTEND ENGINEER</span></h2>
     </div>
   );
 };

--- a/src/components/Designation/index.scss
+++ b/src/components/Designation/index.scss
@@ -5,10 +5,23 @@
   h1,
   h2 {
     // color: #a38a79;
-    font-family: "Poppins", sans-serif;
-    font-weight: 100;
+    font-family: var(--font-heading);
+    font-weight: var(--fw-heading-primary);
     letter-spacing: 1px;
     line-height: 1.2;
+  }
+
+  h1 {
+    font-family: var(--font-nav);
+  }
+
+  h2 {
+    font-family: var(--font-heading-alt, var(--font-heading));
+  }
+
+  .designation_an {
+    font-family: var(--font-nav);
+    text-transform: lowercase;
   }
 
   .designation_name {

--- a/src/components/Header/index.jsx
+++ b/src/components/Header/index.jsx
@@ -1,4 +1,5 @@
 import { NavLink } from "react-router-dom";
+import ThemeToggle from "../ThemeToggle";
 import "./index.scss";
 
 const Header = () => {
@@ -23,6 +24,9 @@ const Header = () => {
         <NavLink to={"/contact"} className="nav_link">
           Contact
         </NavLink>
+      </li>
+      <li>
+        <ThemeToggle />
       </li>
     </ul>
   );

--- a/src/components/Header/index.scss
+++ b/src/components/Header/index.scss
@@ -5,13 +5,13 @@
   display: flex;
   justify-content: space-between;
   color: inherit;
-  font-family: "Montserrat", sans-serif;
+  font-family: var(--font-nav);
 }
 
 .nav_link {
   font-size: 14px;
   text-decoration: none;
-  font-family: "Montserrat", sans-serif;
+  font-family: var(--font-nav);
 
   &:after {
     content: "";

--- a/src/components/MainLoader/index.css
+++ b/src/components/MainLoader/index.css
@@ -9,7 +9,7 @@
   display: flex;
   align-items: center;
   justify-content: center;
-  background-color: #0F0F0F !important;
+  background-color: var(--color-loader-bg) !important;
   z-index: 9999;
 }
 

--- a/src/components/ProjectCard/index.scss
+++ b/src/components/ProjectCard/index.scss
@@ -1,11 +1,11 @@
 .project_card {
-  background-color: var(--color-bg) !important;
-  border: 1px solid var(--color-border) !important;
+  background-color: var(--color-card-bg) !important;
+  border: 1px solid var(--color-card-border) !important;
 
   div,
   span,
   svg {
-    background-color: var(--color-bg) !important;
+    background-color: var(--color-card-bg) !important;
     color: var(--color-text) !important;
   }
 }
@@ -21,6 +21,6 @@
 }
 
 .ant-card-actions {
-  background-color: var(--color-bg) !important;
-  border-top: 0.5px solid var(--color-border) !important;
+  background-color: var(--color-card-bg) !important;
+  border-top: 0.5px solid var(--color-card-border) !important;
 }

--- a/src/components/SkillsList/index.scss
+++ b/src/components/SkillsList/index.scss
@@ -18,7 +18,7 @@
 
   i {
     display: block;
-    color: var(--color-muted);
+    color: var(--color-text-muted);
     opacity: 0;
     /* Default entrance */
     transform: translateY(-5px);

--- a/src/components/ThemeModal/index.jsx
+++ b/src/components/ThemeModal/index.jsx
@@ -1,0 +1,112 @@
+import { useEffect, useRef, useCallback } from 'react';
+import { useTheme } from '../../theme/ThemeContext';
+import { DEFAULT_THEME } from '../../theme/themes';
+import './index.scss';
+
+const ThemeModal = () => {
+  const { isFirstVisit, themes, setTheme, dismissFirstVisit } = useTheme();
+  const modalRef = useRef(null);
+  const firstCardRef = useRef(null);
+
+  const handleSelect = useCallback(
+    (id) => {
+      setTheme(id);
+      dismissFirstVisit();
+    },
+    [setTheme, dismissFirstVisit]
+  );
+
+  // Focus trap + keyboard handling
+  useEffect(() => {
+    if (!isFirstVisit) return;
+
+    // Auto-focus first card
+    firstCardRef.current?.focus();
+
+    // Lock body scroll
+    document.body.style.overflow = 'hidden';
+
+    const handleKeyDown = (e) => {
+      if (e.key === 'Escape') {
+        handleSelect(DEFAULT_THEME);
+        return;
+      }
+
+      if (e.key !== 'Tab') return;
+
+      const focusable = modalRef.current?.querySelectorAll('button');
+      if (!focusable || focusable.length === 0) return;
+
+      const first = focusable[0];
+      const last = focusable[focusable.length - 1];
+
+      if (e.shiftKey) {
+        if (document.activeElement === first) {
+          e.preventDefault();
+          last.focus();
+        }
+      } else {
+        if (document.activeElement === last) {
+          e.preventDefault();
+          first.focus();
+        }
+      }
+    };
+
+    document.addEventListener('keydown', handleKeyDown);
+    return () => {
+      document.body.style.overflow = '';
+      document.removeEventListener('keydown', handleKeyDown);
+    };
+  }, [isFirstVisit, handleSelect]);
+
+  if (!isFirstVisit) return null;
+
+  return (
+    <div
+      className="theme-modal-overlay"
+      role="dialog"
+      aria-modal="true"
+      aria-label="Choose your theme"
+      ref={modalRef}
+    >
+      <div className="theme-modal">
+        <h2 className="theme-modal__title">Choose your vibe</h2>
+        <p className="theme-modal__subtitle">You can always change this later.</p>
+
+        <div className="theme-modal__cards">
+          {themes.map((t, i) => (
+            <button
+              key={t.id}
+              ref={i === 0 ? firstCardRef : undefined}
+              className="theme-modal__card"
+              onClick={() => handleSelect(t.id)}
+              aria-label={`Select ${t.label} theme`}
+            >
+              <div className="theme-modal__swatch" aria-hidden="true">
+                <span
+                  className="theme-modal__swatch-bg"
+                  style={{ background: t.colors.bg }}
+                />
+                <span
+                  className="theme-modal__swatch-accent"
+                  style={{ background: t.colors.accent }}
+                />
+                <span
+                  className="theme-modal__swatch-text"
+                  style={{ color: t.colors.text, background: 'transparent' }}
+                >
+                  Aa
+                </span>
+              </div>
+              <span className="theme-modal__card-label">{t.label}</span>
+              <span className="theme-modal__card-desc">{t.description}</span>
+            </button>
+          ))}
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default ThemeModal;

--- a/src/components/ThemeModal/index.scss
+++ b/src/components/ThemeModal/index.scss
@@ -1,0 +1,139 @@
+.theme-modal-overlay {
+  position: fixed;
+  inset: 0;
+  z-index: 10001;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: rgba(0, 0, 0, 0.7) !important;
+  backdrop-filter: blur(4px);
+  animation: themeModalFadeIn 0.3s ease-out;
+}
+
+.theme-modal {
+  background: var(--color-bg-alt) !important;
+  border: 1px solid var(--color-border);
+  border-radius: 16px;
+  padding: 40px 32px;
+  max-width: 520px;
+  width: 90vw;
+  text-align: center;
+
+  &__title {
+    font-size: 24px;
+    font-weight: 300;
+    margin: 0 0 8px;
+    color: var(--color-text);
+    background: transparent !important;
+  }
+
+  &__subtitle {
+    font-size: 14px;
+    color: var(--color-text-muted);
+    margin: 0 0 32px;
+    background: transparent !important;
+  }
+
+  &__cards {
+    display: flex;
+    gap: 16px;
+    justify-content: center;
+    background: transparent !important;
+  }
+
+  &__card {
+    flex: 1;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    gap: 12px;
+    padding: 20px 16px;
+    border: 1px solid var(--color-border);
+    border-radius: 12px;
+    cursor: pointer;
+    background: var(--color-bg) !important;
+    transition: border-color 0.2s, transform 0.2s;
+
+    &:hover {
+      border-color: var(--color-accent);
+      transform: translateY(-2px);
+    }
+
+    &:focus-visible {
+      outline: 2px solid var(--color-accent);
+      outline-offset: 2px;
+    }
+  }
+
+  &__card-label {
+    font-size: 16px;
+    font-weight: 500;
+    color: var(--color-text);
+    background: transparent !important;
+  }
+
+  &__card-desc {
+    font-size: 12px;
+    color: var(--color-text-muted);
+    background: transparent !important;
+  }
+
+  &__swatch {
+    width: 80px;
+    height: 56px;
+    border-radius: 8px;
+    position: relative;
+    overflow: hidden;
+    border: 1px solid var(--color-border);
+    background: transparent !important;
+  }
+
+  &__swatch-bg {
+    position: absolute;
+    inset: 0;
+  }
+
+  &__swatch-accent {
+    position: absolute;
+    bottom: 0;
+    left: 0;
+    right: 0;
+    height: 6px;
+  }
+
+  &__swatch-text {
+    position: absolute;
+    top: 50%;
+    left: 50%;
+    transform: translate(-50%, -50%);
+    font-size: 18px;
+    font-weight: 600;
+  }
+}
+
+@keyframes themeModalFadeIn {
+  from {
+    opacity: 0;
+  }
+  to {
+    opacity: 1;
+  }
+}
+
+/* Stack cards on mobile */
+@media screen and (max-width: 459px) {
+  .theme-modal__cards {
+    flex-direction: column;
+  }
+}
+
+/* Respect reduced motion */
+@media (prefers-reduced-motion: reduce) {
+  .theme-modal-overlay {
+    animation: none;
+  }
+
+  .theme-modal__card {
+    transition: none;
+  }
+}

--- a/src/components/ThemeToggle/index.jsx
+++ b/src/components/ThemeToggle/index.jsx
@@ -1,0 +1,25 @@
+import { useTheme } from '../../theme/ThemeContext';
+import { getThemeIds } from '../../theme/themes';
+import './index.scss';
+
+const ThemeToggle = () => {
+  const { themeId, setTheme } = useTheme();
+  const ids = getThemeIds();
+
+  const currentIndex = ids.indexOf(themeId);
+  const nextIndex = (currentIndex + 1) % ids.length;
+  const nextId = ids[nextIndex];
+
+  return (
+    <button
+      className="theme-toggle"
+      onClick={() => setTheme(nextId)}
+      aria-label={`Switch to ${nextId.replace('-', ' ')} theme`}
+      title={`Switch to ${nextId.replace('-', ' ')} theme`}
+    >
+      <i className="fa-solid fa-palette" />
+    </button>
+  );
+};
+
+export default ThemeToggle;

--- a/src/components/ThemeToggle/index.scss
+++ b/src/components/ThemeToggle/index.scss
@@ -1,0 +1,26 @@
+.theme-toggle {
+  background: transparent !important;
+  border: none;
+  cursor: pointer;
+  padding: 4px 8px;
+  font-size: 18px;
+  color: var(--color-text-muted);
+  transition: color 0.2s, transform 0.2s;
+  display: flex;
+  align-items: center;
+
+  i {
+    background: transparent !important;
+  }
+
+  &:hover {
+    color: var(--color-accent);
+    transform: scale(1.15);
+  }
+
+  &:focus-visible {
+    outline: 2px solid var(--color-accent);
+    outline-offset: 2px;
+    border-radius: 4px;
+  }
+}

--- a/src/index.css
+++ b/src/index.css
@@ -1,14 +1,10 @@
-:root {
-  --color-bg: black;
-  --color-text: #F8EDE3;
-  --color-accent: #875c3e;
-  --color-border: #454545;
-  --color-muted: #ddd0c3;
-}
+@import './theme/theme-variables.css';
+@import './theme/theme-transition.css';
+@import './theme/poetcore.css';
 
 body, html {
   margin: 0;
-  font-family: 'Montserrat', sans-serif;
+  font-family: var(--font-body);
 }
 
 * {

--- a/src/index.js
+++ b/src/index.js
@@ -1,6 +1,7 @@
 import React from 'react';
 import ReactDOM from 'react-dom/client';
 import { BrowserRouter } from 'react-router-dom';
+import { ThemeProvider } from './theme/ThemeContext';
 import './index.css';
 import App from './App';
 import reportWebVitals from './reportWebVitals';
@@ -9,7 +10,9 @@ const root = ReactDOM.createRoot(document.getElementById('root'));
 root.render(
   <React.StrictMode>
     <BrowserRouter>
-      <App />
+      <ThemeProvider>
+        <App />
+      </ThemeProvider>
     </BrowserRouter>
   </React.StrictMode>
 );

--- a/src/pages/Contact/index.scss
+++ b/src/pages/Contact/index.scss
@@ -1,7 +1,7 @@
 .contact {
     margin: 20vh auto;
     text-align: center;
-    font-family: "Poppins", sans-serif;
+    font-family: var(--font-heading);
 
     h1 {
         font-weight: 200;

--- a/src/pages/Error404/index.scss
+++ b/src/pages/Error404/index.scss
@@ -1,7 +1,7 @@
 .error {
   margin: 20vh auto;
   text-align: center;
-  font-family: "Poppins", sans-serif;
+  font-family: var(--font-heading);
 
   h1 {
     font-weight: 300;

--- a/src/pages/Work/index.scss
+++ b/src/pages/Work/index.scss
@@ -26,5 +26,5 @@
 }
 
 .ant-timeline-item-tail {
-  background-color: var(--color-text);
+  background-color: var(--color-timeline-tail);
 }

--- a/src/theme/ThemeContext.js
+++ b/src/theme/ThemeContext.js
@@ -1,0 +1,105 @@
+import { createContext, useContext, useState, useCallback, useEffect } from 'react';
+import { getTheme, getThemeIds, THEME_STORAGE_KEY, DEFAULT_THEME } from './themes';
+
+const ThemeContext = createContext(null);
+
+function applyThemeToDOM(themeId) {
+  document.documentElement.setAttribute('data-theme', themeId);
+}
+
+function loadGoogleFonts(theme) {
+  if (!theme.googleFonts || theme.googleFonts.length === 0) {
+    // Remove any previously injected theme font links
+    document.querySelectorAll('link[data-theme-fonts]').forEach((el) => el.remove());
+    return;
+  }
+
+  const href = `https://fonts.googleapis.com/css2?${theme.googleFonts
+    .map((f) => `family=${f}`)
+    .join('&')}&display=swap`;
+
+  // Don't inject if an identical link already exists (e.g. from FOUC script)
+  const existing = document.querySelector('link[data-theme-fonts]');
+  if (existing && existing.href === href) return;
+
+  // Remove stale theme font links before adding new one
+  document.querySelectorAll('link[data-theme-fonts]').forEach((el) => el.remove());
+
+  const link = document.createElement('link');
+  link.rel = 'stylesheet';
+  link.href = href;
+  link.setAttribute('data-theme-fonts', 'true');
+  document.head.appendChild(link);
+}
+
+export function ThemeProvider({ children }) {
+  const [themeId, setThemeId] = useState(() => {
+    try {
+      return localStorage.getItem(THEME_STORAGE_KEY) || DEFAULT_THEME;
+    } catch {
+      return DEFAULT_THEME;
+    }
+  });
+
+  const [isFirstVisit] = useState(() => {
+    try {
+      return !localStorage.getItem(THEME_STORAGE_KEY);
+    } catch {
+      return true;
+    }
+  });
+
+  const [firstVisitDismissed, setFirstVisitDismissed] = useState(false);
+
+  const theme = getTheme(themeId);
+
+  const setTheme = useCallback((id) => {
+    const newTheme = getTheme(id);
+    setThemeId(newTheme.id);
+    applyThemeToDOM(newTheme.id);
+    loadGoogleFonts(newTheme);
+    try {
+      localStorage.setItem(THEME_STORAGE_KEY, newTheme.id);
+    } catch {
+      // localStorage unavailable
+    }
+  }, []);
+
+  const dismissFirstVisit = useCallback(() => {
+    setFirstVisitDismissed(true);
+  }, []);
+
+  // Apply theme on mount (FOUC script already set data-theme, but ensure React is in sync)
+  useEffect(() => {
+    applyThemeToDOM(themeId);
+    loadGoogleFonts(getTheme(themeId));
+  }, [themeId]);
+
+  // Enable transitions after first paint to prevent FOUC
+  useEffect(() => {
+    requestAnimationFrame(() => {
+      requestAnimationFrame(() => {
+        document.documentElement.classList.add('theme-transitions-enabled');
+      });
+    });
+  }, []);
+
+  const value = {
+    themeId,
+    theme,
+    setTheme,
+    themes: getThemeIds().map(getTheme),
+    isFirstVisit: isFirstVisit && !firstVisitDismissed,
+    dismissFirstVisit,
+  };
+
+  return <ThemeContext.Provider value={value}>{children}</ThemeContext.Provider>;
+}
+
+export function useTheme() {
+  const ctx = useContext(ThemeContext);
+  if (!ctx) {
+    throw new Error('useTheme must be used within a ThemeProvider');
+  }
+  return ctx;
+}

--- a/src/theme/poetcore.css
+++ b/src/theme/poetcore.css
@@ -1,0 +1,92 @@
+/* ── Poetcore — aged parchment & old books ── */
+
+/* Paper grain texture — subtle noise over parchment */
+html[data-theme="poetcore"] body::before {
+  content: '';
+  position: fixed;
+  inset: 0;
+  pointer-events: none;
+  z-index: 10000;
+  background-color: transparent !important;
+  opacity: var(--texture-opacity, 0.04);
+  mix-blend-mode: multiply;
+  background: repeating-conic-gradient(
+    #8B7B6B 0% 25%,
+    transparent 0% 50%
+  ) 0 0 / 3px 3px;
+}
+
+/* Global italic + scrollbar — flowy text & warm leather tones (html only to avoid overflow) */
+html[data-theme="poetcore"] {
+  font-style: italic;
+  scrollbar-width: thin;
+  scrollbar-color: var(--color-scrollbar-thumb) var(--color-scrollbar-track);
+}
+html[data-theme="poetcore"]::-webkit-scrollbar {
+  display: block;
+  width: 6px;
+}
+html[data-theme="poetcore"]::-webkit-scrollbar-track {
+  background: var(--color-scrollbar-track);
+}
+html[data-theme="poetcore"]::-webkit-scrollbar-thumb {
+  background: var(--color-scrollbar-thumb);
+  border-radius: 3px;
+}
+html[data-theme="poetcore"]::-webkit-scrollbar-thumb:hover {
+  background: var(--color-scrollbar-thumb-hover);
+}
+
+/* Text selection — amber highlight */
+html[data-theme="poetcore"] ::selection {
+  background: var(--color-selection-bg);
+  color: var(--color-selection-text);
+}
+
+/* Body text opacity — slightly faded ink look */
+html[data-theme="poetcore"] p {
+  opacity: var(--body-opacity, 0.8);
+}
+
+/* Link styling — warm brown ink */
+html[data-theme="poetcore"] a {
+  color: var(--color-link);
+}
+html[data-theme="poetcore"] a:hover {
+  color: var(--color-link-hover);
+}
+
+/* Card frames — leather-bound book edge effect */
+html[data-theme="poetcore"] .project_card {
+  box-shadow: inset 0 0 0 1px var(--color-card-border),
+              inset 0 0 0 3px var(--color-card-bg),
+              inset 0 0 0 4px var(--color-card-border);
+}
+
+/* Ambient warmth — subtle box-shadow instead of pseudo-elements (no overflow) */
+html[data-theme="poetcore"] .app-content-enter {
+  box-shadow: inset 0 0 200px rgba(201, 168, 124, 0.08);
+}
+
+/* Card hover — lift with warm shadow */
+html[data-theme="poetcore"] .project_card:hover {
+  transform: translateY(-4px);
+  box-shadow: inset 0 0 0 1px var(--color-accent),
+              0 8px 24px rgba(43, 29, 14, 0.15);
+}
+
+/* Loader icon — sepia warmth */
+html[data-theme="poetcore"] .cl-sq--fa i {
+  filter: sepia(0.3) brightness(0.9);
+}
+
+/* Nav links — italic serif elegance */
+html[data-theme="poetcore"] .nav_link {
+  font-style: italic;
+  letter-spacing: 0.5px;
+}
+
+/* Nav underline — use accent brown instead of text color */
+html[data-theme="poetcore"] .nav_link:after {
+  background: var(--color-accent) !important;
+}

--- a/src/theme/theme-transition.css
+++ b/src/theme/theme-transition.css
@@ -1,0 +1,21 @@
+/* ── Theme Transitions ── */
+/* Only active after first paint to prevent FOUC */
+html.theme-transitions-enabled *,
+html.theme-transitions-enabled *::before,
+html.theme-transitions-enabled *::after {
+  transition:
+    background-color 350ms ease,
+    color 350ms ease,
+    border-color 350ms ease,
+    fill 350ms ease,
+    box-shadow 350ms ease;
+}
+
+/* Respect user motion preferences */
+@media (prefers-reduced-motion: reduce) {
+  html.theme-transitions-enabled *,
+  html.theme-transitions-enabled *::before,
+  html.theme-transitions-enabled *::after {
+    transition: none !important;
+  }
+}

--- a/src/theme/theme-variables.css
+++ b/src/theme/theme-variables.css
@@ -1,0 +1,66 @@
+/* ── Theme Variables ── */
+/* Dark Minimal (default) */
+html,
+html[data-theme="dark-minimal"] {
+  --color-bg: #000000;
+  --color-bg-alt: #0A0A0A;
+  --color-text: #F8EDE3;
+  --color-text-muted: #ddd0c3;
+  --color-accent: #875c3e;
+  --color-accent-hover: #a06d4a;
+  --color-border: #454545;
+  --color-link: #F8EDE3;
+  --color-link-hover: #875c3e;
+  --color-selection-bg: #875c3e;
+  --color-selection-text: #F8EDE3;
+  --color-scrollbar-track: #000000;
+  --color-scrollbar-thumb: #454545;
+  --color-scrollbar-thumb-hover: #875c3e;
+  --color-loader-bg: #0F0F0F;
+  --color-card-bg: #000000;
+  --color-card-border: #454545;
+  --color-timeline-dot: #875c3e;
+  --color-timeline-tail: #F8EDE3;
+  --font-heading: 'Poppins', sans-serif;
+  --font-body: 'Montserrat', sans-serif;
+  --font-nav: 'Montserrat', sans-serif;
+  --font-accent: 'Poppins', sans-serif;
+  --fw-heading-primary: 100;
+  --fw-heading-secondary: 200;
+  --body-opacity: 1;
+  --texture-opacity: 0;
+  --ornament-display: none;
+}
+
+/* Poetcore — rosy greige, old books */
+html[data-theme="poetcore"] {
+  --color-bg: #E3DADB;
+  --color-bg-alt: #D9D0D1;
+  --color-text: #2B1D0E;
+  --color-text-muted: #7A6A5E;
+  --color-accent: #8B4513;
+  --color-accent-hover: #A0522D;
+  --color-border: #BFB3A5;
+  --color-link: #6B3A2A;
+  --color-link-hover: #8B4513;
+  --color-selection-bg: #C9A87C;
+  --color-selection-text: #2B1D0E;
+  --color-scrollbar-track: #D9D0D1;
+  --color-scrollbar-thumb: #BFB3A5;
+  --color-scrollbar-thumb-hover: #8B4513;
+  --color-loader-bg: #E3DADB;
+  --color-card-bg: #D9D0D1;
+  --color-card-border: #BFB3A5;
+  --color-timeline-dot: #8B4513;
+  --color-timeline-tail: #BFB3A5;
+  --font-heading: 'Pinyon Script', cursive;
+  --font-body: 'EB Garamond', serif;
+  --font-nav: 'EB Garamond', serif;
+  --font-accent: 'Bodoni Moda', serif;
+  --font-heading-alt: 'Cinzel', serif;
+  --fw-heading-primary: 400;
+  --fw-heading-secondary: 400;
+  --body-opacity: 0.8;
+  --texture-opacity: 0.04;
+  --ornament-display: block;
+}

--- a/src/theme/themes.js
+++ b/src/theme/themes.js
@@ -1,0 +1,105 @@
+export const THEME_STORAGE_KEY = 'portfolio-theme';
+export const DEFAULT_THEME = 'dark-minimal';
+
+const themes = {
+  'dark-minimal': {
+    id: 'dark-minimal',
+    label: 'Dark Minimal',
+    description: 'Clean and modern dark theme',
+    colors: {
+      bg: '#000000',
+      'bg-alt': '#0A0A0A',
+      text: '#F8EDE3',
+      'text-muted': '#ddd0c3',
+      accent: '#875c3e',
+      'accent-hover': '#a06d4a',
+      border: '#454545',
+      link: '#F8EDE3',
+      'link-hover': '#875c3e',
+      'selection-bg': '#875c3e',
+      'selection-text': '#F8EDE3',
+      'scrollbar-track': '#000000',
+      'scrollbar-thumb': '#454545',
+      'scrollbar-thumb-hover': '#875c3e',
+      'loader-bg': '#0F0F0F',
+      'card-bg': '#000000',
+      'card-border': '#454545',
+      'timeline-dot': '#875c3e',
+      'timeline-tail': '#F8EDE3',
+    },
+    fonts: {
+      heading: "'Poppins', sans-serif",
+      body: "'Montserrat', sans-serif",
+      nav: "'Montserrat', sans-serif",
+      accent: "'Poppins', sans-serif",
+    },
+    fontWeights: {
+      'heading-primary': 100,
+      'heading-secondary': 200,
+    },
+    extra: {
+      'body-opacity': 1,
+      'texture-opacity': 0,
+      'ornament-display': 'none',
+    },
+    googleFonts: [],
+  },
+
+  poetcore: {
+    id: 'poetcore',
+    label: 'Poetcore',
+    description: 'Aged parchment & old books',
+    colors: {
+      bg: '#E3DADB',
+      'bg-alt': '#D9D0D1',
+      text: '#2B1D0E',
+      'text-muted': '#7A6A5E',
+      accent: '#8B4513',
+      'accent-hover': '#A0522D',
+      border: '#BFB3A5',
+      link: '#6B3A2A',
+      'link-hover': '#8B4513',
+      'selection-bg': '#C9A87C',
+      'selection-text': '#2B1D0E',
+      'scrollbar-track': '#D9D0D1',
+      'scrollbar-thumb': '#BFB3A5',
+      'scrollbar-thumb-hover': '#8B4513',
+      'loader-bg': '#E3DADB',
+      'card-bg': '#D9D0D1',
+      'card-border': '#BFB3A5',
+      'timeline-dot': '#8B4513',
+      'timeline-tail': '#BFB3A5',
+    },
+    fonts: {
+      heading: "'Pinyon Script', cursive",
+      body: "'EB Garamond', serif",
+      nav: "'EB Garamond', serif",
+      accent: "'Bodoni Moda', serif",
+    },
+    fontWeights: {
+      'heading-primary': 400,
+      'heading-secondary': 400,
+    },
+    extra: {
+      'body-opacity': 0.8,
+      'texture-opacity': 0.04,
+      'ornament-display': 'block',
+    },
+    googleFonts: [
+      'EB+Garamond:ital,wght@0,400;0,500;0,600;1,400;1,500',
+      'Pinyon+Script',
+      'Bodoni+Moda:wght@400;700',
+      'Cinzel:wght@400;500;600;700',
+    ],
+  },
+};
+
+export function getTheme(id) {
+  return themes[id] || themes[DEFAULT_THEME];
+}
+
+export function getThemeIds() {
+  return Object.keys(themes);
+}
+
+export default themes;


### PR DESCRIPTION
- Add theme system (ThemeContext, ThemeModal, ThemeToggle)
- Poetcore: Pinyon Script headings, Cinzel subtitle, EB Garamond body
- Fix overflow from decorative blur pseudo-elements (replaced with box-shadow)
- Fix scrollbar override to html-only to prevent overflow
- Add global italic for poetcore, mauve-tinted background
- Update FOUC font preload in index.html
- Migrate all component styles to CSS custom properties